### PR TITLE
Optimize analytic report service

### DIFF
--- a/lib/ossboard/repositories/task_repository.rb
+++ b/lib/ossboard/repositories/task_repository.rb
@@ -12,9 +12,21 @@ class TaskRepository < Hanami::Repository
   end
 
   def all_from_date(from, status = nil)
-    request = tasks.where("created_at > '#{from}'").where("created_at < '#{Time.now}'")
-    request = request.where(status: status) if status
-    request.as(Task).to_a
+    all_from_date_request(from, status).as(Task).to_a
+  end
+
+  def all_from_date_counted_by_status_and_day(from)
+    result = all_from_date_request(from)
+      .select{ [count(:id), :status, Sequel.lit('created_at::date')] }
+      .group(:status, Sequel.lit('created_at::date'))
+      .order(nil)
+      .to_a
+      .group_by(&:status)
+
+    result.each do |status, records_by_status|
+      result[status] = {}
+      records_by_status.each { |record| result[status][record.created_at] = record.count }
+    end
   end
 
   def find_by_status(status)
@@ -27,5 +39,13 @@ class TaskRepository < Hanami::Repository
 
   def on_moderation_for_user(id)
     tasks.where(user_id: id, approved: nil).order(Sequel.lit('? DESC', :id)).as(Task).to_a
+  end
+
+  private
+
+  def all_from_date_request(from, status = nil)
+    request = tasks.where("created_at > '#{from}'").where("created_at < '#{Time.now}'")
+    request = request.where(status: status) if status
+    request
   end
 end

--- a/lib/ossboard/services/analytic_reporter.rb
+++ b/lib/ossboard/services/analytic_reporter.rb
@@ -3,55 +3,47 @@ class AnalyticReporter
     {
       labels: last_month_list.map(&:to_s),
       tasks: {
-        in_progress: count_days(in_progress_tasks_by_day),
-        assigned: count_days(assigned_tasks_by_day),
-        closed: count_days(closed_tasks_by_day),
-        done: count_days(complited_tasks_by_day)
+        in_progress: count_days(in_progress_tasks_by_day_count),
+        assigned: count_days(assigned_tasks_by_day_count),
+        closed: count_days(closed_tasks_by_day_count),
+        done: count_days(complited_tasks_by_day_count)
       },
-      users: count_days(users_by_days)
+      users: count_days(users_by_day_count)
     }
   end
 
   private
 
   def count_days(collection)
-    last_month_list.map { |day| collection[day]&.count || 0 }
+    last_month_list.map { |day| collection[day] || 0 }
   end
 
-  def users_by_days
-    @users_by_days ||= UserRepository.new.all_from_date(ONE_MONTH_AGO).group_by{ |u| u.created_at.to_date }
+  def users_by_day_count
+    @users_by_day ||= UserRepository.new.count_all_from_date(ONE_MONTH_AGO)
   end
 
-  def closed_tasks_by_day
-    tasks_by_status_and_day.fetch(Task::VALID_STATUSES[:closed], {})
+  def closed_tasks_by_day_count
+    tasks_by_status_and_day_count.fetch(Task::VALID_STATUSES[:closed], {})
   end
 
-  def assigned_tasks_by_day
-    tasks_by_status_and_day.fetch(Task::VALID_STATUSES[:assigned], {})
+  def assigned_tasks_by_day_count
+    tasks_by_status_and_day_count.fetch(Task::VALID_STATUSES[:assigned], {})
   end
 
-  def in_progress_tasks_by_day
-    tasks_by_status_and_day.fetch(Task::VALID_STATUSES[:in_progress], {})
+  def in_progress_tasks_by_day_count
+    tasks_by_status_and_day_count.fetch(Task::VALID_STATUSES[:in_progress], {})
   end
 
-  def complited_tasks_by_day
-    tasks_by_status_and_day.fetch(Task::VALID_STATUSES[:done], {})
+  def complited_tasks_by_day_count
+    tasks_by_status_and_day_count.fetch(Task::VALID_STATUSES[:done], {})
   end
 
-  def tasks_by_status_and_day
-    return @tasks_by_status_and_day if @tasks_by_status_and_day
-    @tasks_by_status_and_day = task_repo.all_from_date(ONE_MONTH_AGO).group_by(&:status)
-    @tasks_by_status_and_day.each do |k, v|
-      @tasks_by_status_and_day[k] = v.group_by { |task| task.created_at.to_date }
-    end
+  def tasks_by_status_and_day_count
+    @tasks_by_status_and_day_count ||= TaskRepository.new.all_from_date_counted_by_status_and_day(ONE_MONTH_AGO)
   end
 
   def last_month_list
     @last_month_list ||= (ONE_MONTH_AGO..Date.today)
-  end
-
-  def task_repo
-    @task_repo ||= TaskRepository.new
   end
 
   ONE_MONTH_AGO = Date.today - 30

--- a/spec/ossboard/repositories/task_repository_spec.rb
+++ b/spec/ossboard/repositories/task_repository_spec.rb
@@ -138,6 +138,25 @@ RSpec.describe TaskRepository do
       Timecop.freeze(Time.now + (2 * 60 * 60 * 24)) { Fabricate.create(:task) }
     end
 
+    describe '#all_from_date_counted_by_status_and_day' do
+      before(:all) do
+        3.times do |i|
+          Timecop.freeze(Time.utc(2016, 02, 20 + i)) do
+            Fabricate.create(:task, status: 'done')
+            Fabricate.create(:task, status: 'in progress')
+            Fabricate.create(:task, status: 'closed')
+            Fabricate.create(:task, status: 'assigned')
+          end
+        end
+      end
+
+      let (:result) { repo.all_from_date_counted_by_status_and_day(Time.new(2016, 02, 20)) }
+
+      it { expect(result).to be_a(Hash) }
+      it { expect(result['done'].count).to eq 2 }
+      it { expect(result.dig('closed', Date.new(2016, 02, 22))).to eq 1 }
+    end
+
     after(:all) { TaskRepository.new.clear }
 
     let(:date) { Date.new(2016, 02, 18) }

--- a/spec/ossboard/repositories/user_repository_spec.rb
+++ b/spec/ossboard/repositories/user_repository_spec.rb
@@ -42,6 +42,24 @@ RSpec.describe UserRepository do
     it { expect(repo.all_from_date(date).count).to eq 3 }
   end
 
+  describe '#count_all_from_date' do
+    before do
+      Timecop.freeze(Time.utc(2016, 02, 16)) { Fabricate.create(:user) }
+      Timecop.freeze(Time.utc(2016, 02, 19)) { Fabricate.create(:user) }
+      Timecop.freeze(Time.utc(2016, 02, 20)) do
+        Fabricate.create(:user)
+        Fabricate.create(:user)
+      end
+    end
+
+    let(:date) { Date.new(2016, 02, 17) }
+    let(:result) { repo.count_all_from_date(date) }
+
+    it { expect(result).to be_a(Hash) }
+    it { expect(result[Date.new(2016, 02, 16)]).to be nil }
+    it { expect(result[Date.new(2016, 02, 20)]).to eq 2 }
+  end
+
   describe '#find_by_login_with_tasks' do
     let(:task_repo) { TaskRepository.new }
 


### PR DESCRIPTION
This PR is related to #30 "Reduce memory allocation for AnalyticReporter service"

implemented the following:
- Group and count tasks and users inside of SQL query
- Reduce queries for tasks from 4 to 1

It should significantly boost the speed and reduce the memory usage for the AnalyticReporter service.