### PR TITLE
Fix sidekiq connection pool settings

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,8 +1,25 @@
 if Hanami.env?(:production)
   uri = URI.parse(ENV.fetch("REDISTOGO_URL"))
-  REDIS = ConnectionPool.new(size: 10, timeout: 3) { Redis.new(driver: :hiredis, host: uri.host, port: uri.port, password: uri.password) }
+  redis_conn = proc do
+    Redis.new(
+      driver: :hiredis,
+      host: uri.host,
+      port: uri.port,
+      password: uri.password
+    )
+  end
+
+  REDIS_CLIENT = ConnectionPool.new(size: 10, timeout: 3, &redis_conn)
+  REDIS_SERVER = ConnectionPool.new(size: 27, timeout: 3, &redis_conn)
+
 elsif Hanami.env?(:test)
-  REDIS = ConnectionPool.new(size: 10, timeout: 3) { MockRedis.new }
+  REDIS = REDIS_CLIENT = REDIS_SERVER = ConnectionPool.new(size: 10, timeout: 3) do
+    MockRedis.new
+  end
+
 else
-  REDIS = ConnectionPool.new(size: 10, timeout: 3) { Redis.new(host: 'localhost', port: 6379) }
+  redis_conn = proc { Redis.new(host: 'redis', port: 6379) }
+
+  REDIS_CLIENT = ConnectionPool.new(size: 5, timeout: 3, &redis_conn)
+  REDIS_SERVER = ConnectionPool.new(size: 27, timeout: 3, &redis_conn)
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,7 @@
 Sidekiq.configure_server do |config|
-  config.redis = REDIS
+  config.redis = REDIS_SERVER
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = REDIS
+  config.redis = REDIS_CLIENT
 end


### PR DESCRIPTION
There was a problem with Redis connection pool configuration, sidekiq printed such errors infinitely:

```
2017-01-30T14:23:27.075Z 11911 TID-gnzz5lr08 ERROR: Error fetching job: Waited 3 sec
2017-01-30T14:23:27.083Z 11911 TID-gnzz5lr08 ERROR: /app/vendor/bundle/ruby/2.3.0/gems/connection_pool-2.2.1/lib/connection_pool/timed_stack.rb:86:in `block (2 levels) in pop'
2017-01-30T14:23:27.083Z 11911 TID-gnzz5lr08 ERROR: /app/vendor/bundle/ruby/2.3.0/gems/connection_pool-2.2.1/lib/connection_pool/timed_stack.rb:78:in `loop'
2017-01-30T14:23:27.083Z 11911 TID-gnzz5lr08 ERROR: /app/vendor/bundle/ruby/2.3.0/gems/connection_pool-2.2.1/lib/connection_pool/timed_stack.rb:78:in `block in pop'
2017-01-30T14:23:27.083Z 11911 TID-gnzz5lr08 ERROR: /app/vendor/bundle/ruby/2.3.0/gems/connection_pool-2.2.1/lib/connection_pool/timed_stack.rb:77:in `synchronize'
2017-01-30T14:23:27.083Z 11911 TID-gnzz5lr08 ERROR: /app/vendor/bundle/ruby/2.3.0/gems/connection_pool-2.2.1/lib/connection_pool/timed_stack.rb:77:in `pop'
2017-01-30T14:23:27.083Z 11911 TID-gnzz5lr08 ERROR: /app/vendor/bundle/ruby/2.3.0/gems/connection_pool-2.2.1/lib/connection_pool.rb:89:in `checkout'
2017-01-30T14:23:27.083Z 11911 TID-gnzz5lr08 ERROR: /app/vendor/bundle/ruby/2.3.0/gems/connection_pool-2.2.1/lib/connection_pool.rb:61:in `block in with'
2017-01-30T14:23:27.083Z 11911 TID-gnzz5lr08 ERROR: /app/vendor/bundle/ruby/2.3.0/gems/connection_pool-2.2.1/lib/connection_pool.rb:60:in `handle_interrupt'
2017-01-30T14:23:27.083Z 11911 TID-gnzz5lr08 ERROR: /app/vendor/bundle/ruby/2.3.0/gems/connection_pool-2.2.1/lib/connection_pool.rb:60:in `with'
```

It runed out, that size of connection pool for server was too small, so I increased it according to https://github.com/mperham/sidekiq/issues/1941, also separating configurations for the client and the server